### PR TITLE
fix: ensure finite star coordinates

### DIFF
--- a/src/components/canvas/Stars.jsx
+++ b/src/components/canvas/Stars.jsx
@@ -6,10 +6,11 @@ import { Suspense, useRef, useState } from "react";
 const Stars = (props) => {
   const ref = useRef();
   const [sphere] = useState(() => {
-    const positions = random.inSphere(new Float32Array(5000), { radius: 1.2 });
-    // 验证并清理 NaN 值
+    // 需要为每个顶点提供三个坐标，因此数组长度应为 3 的倍数
+    const positions = random.inSphere(new Float32Array(15000), { radius: 1.2 });
+    // 验证并清理所有非有限值
     for (let i = 0; i < positions.length; i++) {
-      if (isNaN(positions[i])) {
+      if (!Number.isFinite(positions[i])) {
         positions[i] = 0;
       }
     }


### PR DESCRIPTION
## Summary
- fix sphere point generation using float array of length divisible by three
- filter non-finite coordinates when generating stars to avoid NaN in bounding sphere

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bda699648323bfe6c772660db1cb