### PR TITLE
feat: add lazy loaded project gallery

### DIFF
--- a/src/Projects/spot-finder.jsx
+++ b/src/Projects/spot-finder.jsx
@@ -1,11 +1,13 @@
-import React from 'react';
-import {Container, Typography, Card, CardContent, Box, IconButton} from '@mui/material';
-import SpotFinderImages from '../utils/getImages.jsx';
+import React, { useState, Suspense } from 'react';
+import { Container, Typography, Card, CardContent, Box, IconButton, Button, Dialog, DialogContent } from '@mui/material';
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
-import {useNavigate} from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+
+const LazySpotFinderImages = React.lazy(() => import('../utils/getImages.jsx'));
 
 const SpotFinder = () => {
     const navigate = useNavigate();
+    const [openGallery, setOpenGallery] = useState(false);
 
     const handleReturn = () => {
         navigate(-1); // This navigates back to the previous page
@@ -72,12 +74,21 @@ const SpotFinder = () => {
                     <Typography variant="h5" component="h3" gutterBottom>
                         Pictures of USYD Coding Fest 2024
                     </Typography>
-                    <SpotFinderImages />
+                    <Button variant="outlined" onClick={() => setOpenGallery(true)}>
+                        View Photos
+                    </Button>
                 </CardContent>
             </Card>
-            </Card>
+
+            <Dialog open={openGallery} onClose={() => setOpenGallery(false)} maxWidth="lg" fullWidth>
+                <DialogContent>
+                    <Suspense fallback={<div>Loading...</div>}>
+                        <LazySpotFinderImages />
+                    </Suspense>
+                </DialogContent>
+            </Dialog>
         </Container>
     );
-}
+};
 
 export default SpotFinder;

--- a/src/utils/getImages.jsx
+++ b/src/utils/getImages.jsx
@@ -1,23 +1,34 @@
 import React, { useState, useEffect } from 'react';
 import { ImageList, ImageListItem, Grow } from '@mui/material';
 
-// 动态导入图片
-const images = import.meta.glob('../public/USYDCodingFest/*.{jpg,png,gif}', { eager: true });
-
-const allItemData = Object.keys(images).map((key) => {
-    return {
-        img: images[key].default,
-        title: key.split('/').pop().split('.')[0], // 使用文件名作为标题
-    };
-});
-
-const shuffledItemData = allItemData.sort(() => Math.random() - 0.5);
-
 export default function SpotFinderImages() {
-    const [visibleImages, setVisibleImages] = useState(shuffledItemData.slice(0, 8));
-    const [checkedStates, setCheckedStates] = useState(new Array(8).fill(false));
+    const [allImages, setAllImages] = useState([]);
+    const [visibleImages, setVisibleImages] = useState([]);
+    const [checkedStates, setCheckedStates] = useState([]);
 
     useEffect(() => {
+        const loadImages = async () => {
+            const modules = import.meta.glob('../public/USYDCodingFest/*.{jpg,png,gif}');
+            const loadedImages = await Promise.all(
+                Object.keys(modules).map(async (key) => {
+                    const module = await modules[key]();
+                    return {
+                        img: module.default,
+                        title: key.split('/').pop().split('.')[0],
+                    };
+                })
+            );
+            const shuffled = loadedImages.sort(() => Math.random() - 0.5);
+            setAllImages(shuffled);
+            setVisibleImages(shuffled.slice(0, 8));
+            setCheckedStates(new Array(8).fill(false));
+        };
+        loadImages();
+    }, []);
+
+    useEffect(() => {
+        if (visibleImages.length === 0) return;
+
         const showImagesSequentially = () => {
             visibleImages.forEach((_, index) => {
                 setTimeout(() => {
@@ -37,30 +48,26 @@ export default function SpotFinderImages() {
                 setTimeout(() => {
                     setCheckedStates((prevStates) => {
                         const newStates = [...prevStates];
-                        newStates[index] = false; // 隐藏每个图片
+                        newStates[index] = false;
                         return newStates;
                     });
-                }, index * 300); // 延迟300ms逐步隐藏
+                }, index * 300);
             });
 
             setTimeout(() => {
                 setVisibleImages((prevImages) => {
-                    const nextStartIndex = allItemData.indexOf(prevImages[prevImages.length - 1]) + 1;
-                    let newImages;
-                    newImages = [
+                    const nextStartIndex = allImages.indexOf(prevImages[prevImages.length - 1]) + 1;
+                    return [
                         ...prevImages.slice(1),
-                        allItemData[nextStartIndex % allItemData.length]
+                        allImages[nextStartIndex % allImages.length],
                     ];
-                    return newImages;
                 });
                 showImagesSequentially();
-            }, 300 * visibleImages.length); // 在隐藏图片后延迟再开始显示
+            }, 300 * visibleImages.length);
         }, 5000);
 
-        return () => {
-            clearInterval(interval);
-        };
-    }, [visibleImages]);
+        return () => clearInterval(interval);
+    }, [visibleImages, allImages]);
 
     return (
         <ImageList
@@ -79,6 +86,7 @@ export default function SpotFinderImages() {
                         <img
                             src={item.img}
                             alt={item.title}
+                            loading="lazy"
                             style={{ width: '100%', height: '100%', objectFit: 'cover' }}
                         />
                     </ImageListItem>


### PR DESCRIPTION
## Summary
- add photo gallery modal to Spot Finder project
- lazy-load project images with `React.lazy` and browser `loading="lazy"`

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e432c04c8323a97a310cdf6f508e