### PR TITLE
chore: include char-anime dist in Tailwind scan

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,6 +4,7 @@ module.exports = {
     "./src/**/*.{js,jsx}",
     "./packages/video-to-ascii/src/**/*.{js,jsx,ts,tsx}",
     "./packages/charAnime/src/**/*.{js,jsx,ts,tsx}",
+    "./node_modules/char-anime/dist/**/*.{js,jsx,ts,tsx}",
   ],
   mode: "jit",
   darkMode: "class",


### PR DESCRIPTION
## Summary
- include `char-anime` package dist in Tailwind CSS content scanning

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config file)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ab5366c79883238d977c188a5f44a2